### PR TITLE
🐛 모든페이지에서 패널이 자동으로 열리던 문제 수정

### DIFF
--- a/extension/src/contentScript/UnsolvedFloatButton.tsx
+++ b/extension/src/contentScript/UnsolvedFloatButton.tsx
@@ -32,6 +32,7 @@ const UnsolvedFloatButton = () => {
       if (result) {
         setSelectedIndex(3);
         setIsClicked(result);
+        Storage.set('isClicked', false);
       }
     });
     return () => {


### PR DESCRIPTION
# Fix
- chrome storage isClicked 값을 초기화 해주는 로직이 없어서 모든 페이지에서 자동으로 패널이 열리는 문제 해결