### PR TITLE
Feat/make refresh btn in ranking view

### DIFF
--- a/extension/src/api/api.ts
+++ b/extension/src/api/api.ts
@@ -74,12 +74,23 @@ const ProblemService = {
 };
 
 const RankingService = {
+  /**
+   * 랭킹 전체 조회
+   * @param teamId
+   * @returns
+   */
   getAllRanking: async (teamId: string) => {
     return serviceInterface<Ranking[]>(convertURL([UNSOLVED_BASE_URL, 'rankings', teamId]), 'GET');
   },
+  /**
+   * 월간 랭킹
+   * @param teamId
+   * @returns
+   */
   getMonthRanking: async (teamId: string) => {
-    return serviceInterface<Ranking[]>(convertURL([UNSOLVED_BASE_URL, 'rankings', teamId, 'month']), 'GET');
+    return serviceInterface<Ranking[]>(convertURL([UNSOLVED_BASE_URL, 'rankings', 'month', teamId]), 'GET');
   },
+  // TODO: 월간 랭킹 히스토리 조회 api 추가 예정??
 };
 
 const ExternalService = {

--- a/extension/src/api/api.ts
+++ b/extension/src/api/api.ts
@@ -75,10 +75,10 @@ const ProblemService = {
 
 const RankingService = {
   getAllRanking: async (teamId: string) => {
-    return serviceInterface<Ranking[]>(convertURL([UNSOLVED_BASE_URL, 'ranking', teamId]), 'GET');
+    return serviceInterface<Ranking[]>(convertURL([UNSOLVED_BASE_URL, 'rankings', teamId]), 'GET');
   },
   getMonthRanking: async (teamId: string) => {
-    return serviceInterface<Ranking[]>(convertURL([UNSOLVED_BASE_URL, 'ranking', teamId, 'month']), 'GET');
+    return serviceInterface<Ranking[]>(convertURL([UNSOLVED_BASE_URL, 'rankings', teamId, 'month']), 'GET');
   },
 };
 

--- a/extension/src/contentScript/components/panel/ContentPanelBody.tsx
+++ b/extension/src/contentScript/components/panel/ContentPanelBody.tsx
@@ -38,7 +38,7 @@ const ContentPanelBody = ({ selectedIndex }: Props) => {
       {
         {
           0: <ProfileView refresh={toggleAction} />,
-          1: <RankingView />,
+          1: <RankingView refresh={toggleAction} />,
           2: <RecommandView refresh={toggleAction} />,
           3: <ScoringView />,
         }[selectedIndex]

--- a/extension/src/contentScript/components/panel/views/RankingView.tsx
+++ b/extension/src/contentScript/components/panel/views/RankingView.tsx
@@ -1,24 +1,29 @@
-import React, { useEffect, useState } from 'react';
-import { Ranking } from '../../../../@types';
+import React from 'react';
 import { ContentBox, Flex } from '../../../common';
 import { indexToTier } from '../../../utils';
 import { Message } from '../../../../utils';
 import styled from '@emotion/styled';
+import { useRanking } from '../../../hooks/useRanking';
+import { CircularProgress } from '@mui/material';
 
-const RankingView = () => {
-  const [ranking, setRanking] = useState<Ranking[]>([]);
+interface Props {
+  refresh: () => void;
+}
+
+const RankingView = ({ refresh }: Props) => {
+  const { ranking, isLoaded, isFailed } = useRanking();
 
   const redirectUserInfo = (bojId: string) => {
     Message.send({ message: 'toRedirectUser', type: 'sync', data: bojId });
   };
 
-  useEffect(() => {
-    Message.send({ message: 'fetchRanking', type: 'async', data: '1' }, (response) => {
-      if (response.state === 'success') {
-        setRanking(response.data);
-      }
-    });
-  }, []);
+  if (!isLoaded) return <CircularProgress />;
+  if (isFailed)
+    return (
+      <div className='panel-contents'>
+        <ContentBox defined='error' definedAction={refresh} />
+      </div>
+    );
 
   return (
     <div className='panel-contents'>

--- a/extension/src/contentScript/hooks/useRanking.ts
+++ b/extension/src/contentScript/hooks/useRanking.ts
@@ -1,0 +1,28 @@
+import { useEffect, useState } from 'react';
+import { Ranking } from '../../@types';
+import { Message } from '../../utils/message';
+
+export const useRanking = () => {
+  const [ranking, setRanking] = useState<Ranking[]>([]);
+  const [isLoaded, setIsLoaded] = useState(false);
+  const [isFailed, setIsFailed] = useState(false);
+
+  useEffect(() => {
+    // TODO: 해당 그룹의 teamId(data)를 받아와야함
+    Message.send({ message: 'fetchRanking', type: 'async', data: '1' }, (response) => {
+      switch (response.state) {
+        case 'success':
+          setRanking(response.data);
+          break;
+        case 'fail':
+          setIsFailed(true);
+          break;
+        default:
+          break;
+      }
+      setIsLoaded(true);
+    });
+  }, []);
+
+  return { ranking, isLoaded, isFailed };
+};


### PR DESCRIPTION
## 설명
- 랭킹 뷰에 refresh botton & action 추가 했습니다

## 논의 사항
- 백엔드와 논의 사항이긴 한데 ranking 쪽 API가 하나는 동작을 안하고 두개는 기능이 어떻게 다른건지 의아해서 코어타임때 질문해볼 예정
- 만약 랭킹 히스토리도 월별 조회가 가능하도록 한다면 어떤식으로 할 것인지 논의해야 할 것으로 추측