### PR TITLE
Feat/make unsolved random recommand api

### DIFF
--- a/extension/src/@types/index.ts
+++ b/extension/src/@types/index.ts
@@ -132,7 +132,8 @@ export type RequestMessage =
       | 'fetchUser' //
       | 'fetchBadge'
       | 'fetchRanking'
-      | 'fetchRecommand'
+      | 'fetchRecommands'
+      | 'fetchRandomRecommand'
       | 'toLogin'
       | 'hideButton'
       | 'sendNotification'

--- a/extension/src/api/api.ts
+++ b/extension/src/api/api.ts
@@ -70,6 +70,15 @@ const ProblemService = {
   getUnsolvedProblems: async (teamId: string, tier: string) => {
     return serviceInterface<ProblemResponse[]>(convertURL([UNSOLVED_BASE_URL, 'problems', 'unsolved', teamId, tier]), 'GET');
   },
+  /**
+   * 특정 티어의 문제 하나를 추천 받기
+   * @param teamId
+   * @param tier
+   * @returns 추천 문제
+   */
+  getRecommandUnsolvedProblem: async (teamId: string, tier: string) => {
+    return serviceInterface<ProblemResponse[]>(convertURL([UNSOLVED_BASE_URL, 'problems', 'unsolved', 'random', teamId, tier]), 'GET');
+  },
   // 유저 점수 받아오는 api 추가 예정
 };
 

--- a/extension/src/api/mockapi.ts
+++ b/extension/src/api/mockapi.ts
@@ -1,7 +1,7 @@
 import { UnsolvedUser, ProblemResponse, Ranking } from '../@types';
 
 import { dummyUnsolvedUser } from '../test/dummy/dummyUser';
-import { dummyUpdateProblems, dummyProblems } from '../test/dummy/dummyProblem';
+import { dummyUpdateProblems, dummyProblems, dummyProblem } from '../test/dummy/dummyProblem';
 import { dummyAllRanking, dummyMonthRanking } from '../test/dummy/dummyRanking';
 
 function objectToPromise<T>(obj: T): Promise<T> {
@@ -25,6 +25,10 @@ const ProblemService = {
   getUnsolvedProblems: async (bojId: string, tier: string): Promise<ProblemResponse[]> => {
     console.log('mockAPI: getUnsolvedProblems : ', bojId, tier);
     return objectToPromise(dummyProblems);
+  },
+  getRecommandUnsolvedProblem: async (bojId: string, tier: string) => {
+    console.log('mockAPI: getRecommandUnsolvedProblem : ', bojId, tier);
+    return objectToPromise(dummyProblem);
   },
 };
 

--- a/extension/src/background/background.ts
+++ b/extension/src/background/background.ts
@@ -16,8 +16,18 @@ function fetchRanking(sendResponse: SendResponse, teamId: string) {
     });
 }
 
-function fetchRecommand(sendResponse: SendResponse, teamId: string, tier: string) {
+function fetchRecommands(sendResponse: SendResponse, teamId: string, tier: string) {
   API.ProblemService.getUnsolvedProblems(teamId, tier)
+    .then((data) => {
+      sendResponse({ state: 'success', data });
+    })
+    .catch((error) => {
+      sendResponse({ state: 'fail', message: error.message });
+    });
+}
+
+function fetchRandomRecommand(sendResponse: SendResponse, teamId: string, tier: string) {
+  API.ProblemService.getRecommandUnsolvedProblem(teamId, tier)
     .then((data) => {
       sendResponse({ state: 'success', data });
     })
@@ -73,8 +83,11 @@ function asyncRequest(request: Request, sendResponse: SendResponse) {
     case 'fetchRanking':
       fetchRanking(sendResponse, request.data);
       break;
-    case 'fetchRecommand':
-      fetchRecommand(sendResponse, request.data.teamId, request.data.tier);
+    case 'fetchRecommands':
+      fetchRecommands(sendResponse, request.data.teamId, request.data.tier);
+      break;
+    case 'fetchRandomRecommand':
+      fetchRandomRecommand(sendResponse, request.data.teamId, request.data.tier);
       break;
   }
 }

--- a/extension/src/contentScript/components/panel/views/RecommandView.tsx
+++ b/extension/src/contentScript/components/panel/views/RecommandView.tsx
@@ -4,15 +4,17 @@ import { Message, Storage } from '../../../../utils';
 import { numberToTier } from '../../../utils';
 import { tiers } from '../../../utils/numberToTier';
 import styled from '@emotion/styled';
-import { useRecommandProblems } from '../../../hooks/useRecommandProblem';
+import { useRecommandProblems } from '../../../hooks/useRecommandProblems';
 import { CircularProgress } from '@mui/material';
+import { useRandomRecommandProblem } from '../../../hooks/useRandomRecommandProblem';
 
 interface Props {
   refresh: () => void;
 }
 
 const RecommandView = ({ refresh }: Props) => {
-  const { recommand, isLoaded, isFailed } = useRecommandProblems();
+  const { recommand, isLoaded: isLoadedProblems, isFailed: isFailedProblems } = useRecommandProblems();
+  const { randomRecommand, isLoaded: isLoadedProblem, isFailed: isFailedProblem } = useRandomRecommandProblem();
   const [isFilterOpen, setIsFilterOpen] = useState(false);
   const [selectedTiers, setSelectedTiers] = useState<number[]>([]);
 
@@ -41,14 +43,14 @@ const RecommandView = ({ refresh }: Props) => {
     });
   }, []);
 
-  if (!isLoaded) return <CircularProgress />;
-  if (isFailed)
+  if (!isLoadedProblems || !isLoadedProblem) return <CircularProgress />;
+  if (isFailedProblems || isFailedProblem) {
     return (
       <div className='panel-contents'>
         <ContentBox defined='error' definedAction={refresh} />
       </div>
     );
-
+  }
   return (
     <div className='panel-contents'>
       <ContentBox

--- a/extension/src/contentScript/components/panel/views/RecommandView.tsx
+++ b/extension/src/contentScript/components/panel/views/RecommandView.tsx
@@ -83,6 +83,20 @@ const RecommandView = ({ refresh }: Props) => {
           })}
         </FilterBox>
       </ContentBox>
+      {/* TODO: 랜덤 문제 1개 디자인, 포지션 */}
+      {/* TODO: numberToTier를 recommand custom hook 2개에 default로 장착 고려 */}
+      <ContentBox key={randomRecommand.problemId} color={numberToTier(randomRecommand.tier).tier} pointer={true}>
+        <ReccomandBox onClick={() => redirectProblemInfo(randomRecommand.problemId)}>
+          <Flex direction='column' gap='0px' align='start'>
+            <Flex direction='row' justify='space-between'>
+              <span className='problem-id'>No.{randomRecommand.problemId}</span>
+              <span className='problem-tier'>{randomRecommand.tier + ' ' + numberToTier(randomRecommand.tier).level}</span>
+            </Flex>
+            <span className='problem-title'>{randomRecommand.problemTitle}</span>
+          </Flex>
+        </ReccomandBox>
+      </ContentBox>
+      <br />
       {recommand.map(({ problemId, problemTitle, tier }) => {
         const tierInfo = numberToTier(tier);
         return (

--- a/extension/src/contentScript/hooks/useRandomRecommandProblem.ts
+++ b/extension/src/contentScript/hooks/useRandomRecommandProblem.ts
@@ -1,0 +1,27 @@
+import { useEffect, useState } from 'react';
+import { ProblemResponse } from '../../@types';
+import { Message } from '../../utils';
+
+export const useRandomRecommandProblem = () => {
+  const [randomRecommand, setRandomRecommand] = useState<ProblemResponse>(null);
+  const [isLoaded, setIsLoaded] = useState<boolean>(false);
+  const [isFailed, setIsFailed] = useState<boolean>(false);
+
+  useEffect(() => {
+    // TODO: teamId, tier 값은 추후 유저한테서 받아와야함 + default 값
+    Message.send({ message: 'fetchRandomRecommand', type: 'async', data: { teamId: '1', tier: '1' } }, (response) => {
+      switch (response.state) {
+        case 'success':
+          setRandomRecommand(response.data);
+          break;
+        case 'fail':
+          setIsFailed(true);
+          break;
+        default:
+          break;
+      }
+      setIsLoaded(true);
+    });
+  }, []);
+  return { randomRecommand, isLoaded, isFailed };
+};

--- a/extension/src/contentScript/hooks/useRecommandProblems.ts
+++ b/extension/src/contentScript/hooks/useRecommandProblems.ts
@@ -9,7 +9,7 @@ export const useRecommandProblems = () => {
 
   useEffect(() => {
     // TODO: teamId, tier 값은 추후 유저한테서 받아와야함 + default 값
-    Message.send({ message: 'fetchRecommand', type: 'async', data: { teamId: '1', tier: '1' } }, (response) => {
+    Message.send({ message: 'fetchRecommands', type: 'async', data: { teamId: '1', tier: '1' } }, (response) => {
       switch (response.state) {
         case 'success':
           setRecommand(response.data);


### PR DESCRIPTION
## 요약
- 랜덤하게 추천 문제 한개 가져와 주는 API 추가

## 세부사항
- 특정 티어대 unsolved 문제 전체를 가져오는 거랑 random하게 unsolved 문제 1개 가져오는 게 데이터 상관관계를 고려하면 개선할 여지가 있어 보이긴 함(unsolved 문제 전체에서 1 문제다 보니)
- 일단 random하게 가져온 문제 1개는 최상단에 테스트로 넣어놨습니다.
- unsolved 문제 전체가 안오거나 random하게 추천문제 1개를 안가져오거나 하면 무조건 failed contentbox가 나오도록 했습니다