### PR TITLE
Fix : add sideEffect option in css rule

### DIFF
--- a/extension/webpack.common.js
+++ b/extension/webpack.common.js
@@ -25,6 +25,7 @@ module.exports = {
       {
         test: /\.css$/i,
         use: [MiniCssExtractPlugin.loader, 'css-loader'],
+        sideEffects: true,
       },
       {
         test: /\.(jpg|jpeg|png|woff|woff2|eot|ttf|svg)$/,


### PR DESCRIPTION
## DESC
- build시 contentScript.css 생성이 안되는 이슈

## ISSUE
- #43 

## SOLVE
- webpack의 css rule 에서 sideEffect: true를 추가해 문제 해결