### PR TITLE
Fix : modify commands keyword in manifest.json

### DIFF
--- a/extension/src/static/manifest.json
+++ b/extension/src/static/manifest.json
@@ -50,7 +50,7 @@
     }
   ],
   "commands": {
-    "_execute_browser_action": {
+    "_execute_action": {
       "suggested_key": {
         "default": "Ctrl+Shift+9",
         "mac": "Command+Shift+9"


### PR DESCRIPTION
## Desc
- 윈도우에서 build시 command가 menifest action type과 불일치

## 원인
- 해당 manifest command 중에서 v2에 해당하는 action을 사용해서 발생한 오류

## 사진
![image](https://user-images.githubusercontent.com/22931103/218094163-672e31a2-9235-4834-b8a5-1c01da1e1be5.png)
